### PR TITLE
Correct order of parameters in serializer#normalize

### DIFF
--- a/src/json_api_serializer.js
+++ b/src/json_api_serializer.js
@@ -33,7 +33,7 @@ DS.JsonApiSerializer = DS.RESTSerializer.extend({
         }
       }
     }
-    return this._super(type, prop, json);
+    return this._super(type, json, prop);
   },
 
   // SERIALIZATION


### PR DESCRIPTION
It looks like this changed in a recent commit to ember-data. My model's properties were all coming back undefined after a get request before this change.
