### PR TITLE
Add type to arguments for normalizePayload

### DIFF
--- a/src/json_api_serializer.js
+++ b/src/json_api_serializer.js
@@ -39,7 +39,7 @@ DS.JsonApiSerializer = DS.RESTSerializer.extend({
   /**
    * Extract top-level "meta" & "links" before normalizing.
    */
-  normalizePayload: function(payload) {
+  normalizePayload: function(type, payload) {
     if(payload.meta) {
       this.extractMeta(payload.meta);
       delete payload.meta;


### PR DESCRIPTION
As defined in http://ember-doc.com/classes/DS.RESTSerializer.html#method_normalizePayload, there are 2 parameters, type and payload.

As this function returns "payload" which is the first parameter, it actually returns the type to the calling code, and chaos ensues.
