### PR TITLE
updates for ember-data beta.10, `RelationshipChange` was removed

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "tests"
   ],
   "dependencies": {
-    "ember-data": "v1.0.0-beta.8",
+    "ember-data": "v1.0.0-beta.10",
     "ember": "v1.7.0"
   },
   "devDependencies": {

--- a/src/json_api_serializer.js
+++ b/src/json_api_serializer.js
@@ -155,10 +155,7 @@ DS.JsonApiSerializer = DS.RESTSerializer.extend({
     var attr = relationship.key;
     var key = this.keyForRelationship(attr);
 
-    var relationshipType = DS.RelationshipChange.determineRelationshipType(record.constructor, relationship);
-
-    if (relationshipType === 'manyToNone' ||
-        relationshipType === 'manyToMany') {
+    if (relationship.kind === 'hasMany') {
       json.links = json.links || {};
       json.links[key] = get(record, attr).mapBy('id');
     }

--- a/tests/integration/serializer_test.js
+++ b/tests/integration/serializer_test.js
@@ -76,6 +76,7 @@ test('serialize camelcase', function() {
     firstName: 'Tom',
     lastName: 'Dale',
     links: {
+      evilMinions: [],
       homePlanet: get(league, 'id')
     }
   });
@@ -113,6 +114,7 @@ test('serialize into snake_case', function() {
     first_name: 'Tom',
     last_name: 'Dale',
     links: {
+      evil_minions: [],
       home_planet: get(league, 'id')
     }
   });
@@ -132,7 +134,10 @@ test('serializeIntoHash', function() {
 
   deepEqual(json, {
     homePlanet: {
-      name: 'Umber'
+      name: 'Umber',
+      links: {
+        superVillains: []
+      }
     }
   });
 });
@@ -152,7 +157,10 @@ test('serializeIntoHash with decamelized types', function() {
 
   deepEqual(json, {
     homePlanet: {
-      name: 'Umber'
+      name: 'Umber',
+      links: {
+        superVillains: []
+      }
     }
   });
 });


### PR DESCRIPTION
json output changed slightly, associations with no models will now result in an entry in `links`.  This seems desirable.
