### PR TITLE
add .bowerrc file pointing to bower_components

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}


### PR DESCRIPTION
Prevents tests from failing if you have a .bowerrc in a parent directory pointing somewhere else.
