### PR TITLE
Do not override `extractMeta`

### DIFF
--- a/src/json-api-serializer.js
+++ b/src/json-api-serializer.js
@@ -98,13 +98,6 @@ DS.JsonApiSerializer = DS.RESTSerializer.extend({
   },
 
   /**
-   * Override this method to parse the top-level "meta" object per type.
-   */
-  extractMeta: function(meta) {
-    // no op
-  },
-
-  /**
    * Parse the top-level "links" object.
    */
   extractLinks: function(links) {


### PR DESCRIPTION
I think the default implementation of `extractMeta` in `RESTSerializer` is fine for JSON API: https://github.com/emberjs/data/blob/v1.0.0-beta.12/packages/ember-data/lib/serializers/json_serializer.js#L953

```js
  extractMeta: function(store, type, payload) {
    if (payload && payload.meta) {
      store.metaForType(type, payload.meta);
      delete payload.meta;
    }
  }
```