### PR TITLE
Camelize relationship key to make hasMany href relations work

### DIFF
--- a/src/json-api-serializer.js
+++ b/src/json-api-serializer.js
@@ -41,6 +41,7 @@ DS.JsonApiSerializer = DS.RESTSerializer.extend({
       } else if (typeof hash[key] === 'object') {
         for (var link in hash[key]) {
           var linkValue = hash[key][link];
+          link = Ember.String.camelize(link);
           if (linkValue && typeof linkValue === 'object' && linkValue.href) {
             json.links = json.links || {};
             json.links[link] = linkValue.href;


### PR DESCRIPTION
When there is a relationship with a camelized name like `Post.hasMany('someResource')`, but the "links" object has a called 'some_resources' ED could not find the relationship (see test).
This PR camelizes the link key to make that work.

I was thinking about if this should belong somewhere else like inside ED's `normalizeRelationships` function, but doing it inside ember-json-api was easy and since ember-json-api already uses the convention "camel case inside the model, underscores in the JSON payload", doing this inside ember-json-api looks legit.