### PR TITLE
Support Ember 1.0.0-beta.15

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -68,7 +68,7 @@ if (env === 'production') {
       'jquery.js',
       'qunit.js',
       'handlebars.js',
-      'ember.js',
+      'ember.debug.js',
       'ember-data.js'
     ],
     wrapInEval: true,

--- a/bower.json
+++ b/bower.json
@@ -15,8 +15,9 @@
     "tests"
   ],
   "dependencies": {
-    "ember-data": "v1.0.0-beta.10",
-    "ember": "v1.7.0",
+    "ember-data": "v1.0.0-beta.15",
+    "ember": "v1.10.0",
+    "handlebars": "v2.0.0",
     "loader.js": "stefanpenner/loader.js#1.0.1"
   },
   "devDependencies": {

--- a/src/json-api-adapter.js
+++ b/src/json-api-adapter.js
@@ -57,7 +57,8 @@ DS.JsonApiAdapter = DS.RESTAdapter.extend({
   createRecord: function(store, type, record) {
     var data = {};
 
-    data[this.pathForType(type.typeKey)] = store.serializerFor(type.typeKey).serialize(record, {
+    var snapshot = record._createSnapshot();
+    data[this.pathForType(type.typeKey)] = store.serializerFor(type.typeKey).serialize(snapshot, {
       includeId: true
     });
 
@@ -72,7 +73,10 @@ DS.JsonApiAdapter = DS.RESTAdapter.extend({
    */
   updateRecord: function(store, type, record) {
     var data = {};
-    data[this.pathForType(type.typeKey)] = store.serializerFor(type.typeKey).serialize(record, {includeId: true});
+    var snapshot = record._createSnapshot();
+    data[this.pathForType(type.typeKey)] = store.serializerFor(type.typeKey).serialize(snapshot, {
+      includeId: true
+    });
 
     var id = get(record, 'id');
 
@@ -126,7 +130,8 @@ DS.JsonApiAdapter = DS.RESTAdapter.extend({
     */
   serializeIntoHash: function(data, type, record, options) {
     var root = underscore(decamelize(type.typeKey));
-    data[root] = this.serialize(record, options);
+    var snapshot = record._createSnapshot();
+    data[root] = this.serialize(snapshot, options);
   },
 
   pathForType: function(type) {

--- a/tests/integration/serializer-test.js
+++ b/tests/integration/serializer-test.js
@@ -77,7 +77,8 @@ test('serialize camelcase', function() {
   });
 
   var json = Ember.run(function(){
-    return env.serializer.serialize(tom);
+    var snapshot = tom._createSnapshot();
+    return env.serializer.serialize(snapshot);
   });
 
   deepEqual(json, {
@@ -114,8 +115,9 @@ test('serialize into snake_case', function() {
     return Ember.String.decamelize(key);
   };
 
-  var json = Ember.run(function(){
-    return env.serializer.serialize(tom);
+  var json = Ember.run(function() {
+    var snapshot = tom._createSnapshot();
+    return env.serializer.serialize(snapshot);
   });
 
   deepEqual(json, {
@@ -137,7 +139,8 @@ test('serializeIntoHash', function() {
       id: '123'
     });
 
-   env.serializer.serializeIntoHash(json, HomePlanet, league);
+   var snapshot = league._createSnapshot();
+   env.serializer.serializeIntoHash(json, HomePlanet, snapshot);
   });
 
   deepEqual(json, {
@@ -160,7 +163,8 @@ test('serializeIntoHash with decamelized types', function() {
       id: '123'
     });
 
-    env.serializer.serializeIntoHash(json, HomePlanet, league);
+    var snapshot = league._createSnapshot();
+    env.serializer.serializeIntoHash(json, HomePlanet, snapshot);
   });
 
   deepEqual(json, {
@@ -196,7 +200,8 @@ test('serialize has many relationships', function() {
   });
 
   var json = Ember.run(function(){
-    return env.serializer.serialize(drevil);
+    var snapshot = drevil._createSnapshot();
+    return env.serializer.serialize(snapshot);
   });
 
   deepEqual(json, {
@@ -224,7 +229,8 @@ test('serialize belongs to relationships', function() {
   });
 
   var json = Ember.run(function(){
-    return env.serializer.serialize(female);
+    var snapshot = female._createSnapshot();
+    return env.serializer.serialize(snapshot);
   });
 
   deepEqual(json, {


### PR DESCRIPTION
[Ember 1.0.0-beta15 introduced the snapshot API](http://emberjs.com/blog/2015/02/14/ember-data-1-0-beta-15-released.html) which is used in the standard serializers that now expect snapshots instead of models to be passed for serialization. This makes ember-json-api compatible with Ember Data 1.0.0-beta.15.