### PR TITLE
Fix polymorphic belongsTo serialization

### DIFF
--- a/src/json-api-serializer.js
+++ b/src/json-api-serializer.js
@@ -5,6 +5,9 @@ DS.JsonApiSerializer = DS.RESTSerializer.extend({
   keyForRelationship: function(key) {
     return key;
   },
+  keyForSnapshot: function(snapshot) {
+    return snapshot.typeKey;
+  },
   /**
    * Patch the extractSingle method, since there are no singular records
    */
@@ -142,10 +145,11 @@ DS.JsonApiSerializer = DS.RESTSerializer.extend({
   serializeBelongsTo: function(record, json, relationship) {
     var attr = relationship.key;
     var belongsTo = record.belongsTo(attr);
-    var type = this.keyForRelationship(relationship.type.typeKey);
-    var key = this.keyForRelationship(attr);
 
     if (isNone(belongsTo)) return;
+
+    var type = this.keyForSnapshot(belongsTo);
+    var key = this.keyForRelationship(attr);
 
     json.links = json.links || {};
     json.links[key] = belongsToLink(key, type, get(belongsTo, 'id'));

--- a/tests/integration/serializer-test.js
+++ b/tests/integration/serializer-test.js
@@ -1,5 +1,5 @@
 var get = Ember.get, set = Ember.set;
-var HomePlanet, league, SuperVillain, superVillain, EvilMinion, YellowMinion, MaleMinion, FemaleMinion, env;
+var HomePlanet, league, SuperVillain, superVillain, Minion, EvilMinion, YellowMinion, MaleMinion, FemaleMinion, env;
 module('integration/ember-json-api-adapter - serializer', {
   setup: function() {
     SuperVillain = DS.Model.extend({
@@ -20,9 +20,12 @@ module('integration/ember-json-api-adapter - serializer', {
       superVillains: DS.hasMany('superVillain', { async: true })
     });
 
-    EvilMinion = DS.Model.extend({
-      superVillain: DS.belongsTo('superVillain'),
+    Minion = DS.Model.extend({
       name:         DS.attr('string')
+    });
+
+    EvilMinion = Minion.extend({
+      superVillain: DS.belongsTo('superVillain'),
     });
 
     YellowMinion = EvilMinion.extend();
@@ -30,18 +33,20 @@ module('integration/ember-json-api-adapter - serializer', {
       superVillain: DS.belongsTo('megaVillain')
     });
 
-    MaleMinion = DS.Model.extend({
-      wife: DS.belongsTo('femaleMinion')
+    MaleMinion = Minion.extend({
+      wife: DS.belongsTo('femaleMinion', {inverse: 'husband'}),
+      spouse: DS.belongsTo('minion', {polymorphic: true})
     });
 
-    FemaleMinion = DS.Model.extend({
-      husband: DS.belongsTo('maleMinion')
+    FemaleMinion = Minion.extend({
+      husband: DS.belongsTo('maleMinion', {inverse: 'wife'})
     });
 
     env = setupStore({
       superVillain:   SuperVillain,
       megaVillain:    MegaVillain,
       homePlanet:     HomePlanet,
+      minion:         Minion,
       evilMinion:     EvilMinion,
       yellowMinion:   YellowMinion,
       blueMinion:     BlueMinion,
@@ -113,6 +118,10 @@ test('serialize into snake_case', function() {
 
   env.serializer.keyForRelationship = function(key, relationshipKind) {
     return Ember.String.decamelize(key);
+  };
+
+  env.serializer.keyForSnapshot = function(snapshot) {
+    return Ember.String.decamelize(snapshot.typeKey);
   };
 
   var json = Ember.run(function() {
@@ -221,7 +230,9 @@ test('serialize belongs to relationships', function() {
 
   Ember.run(function() {
     // Of course they belong to each other
-    female = env.store.createRecord(FemaleMinion);
+    female = env.store.createRecord(FemaleMinion, {
+      name: 'Bobbie Sue'
+    });
     male = env.store.createRecord(MaleMinion, {
       id: 2,
       wife: female
@@ -239,7 +250,40 @@ test('serialize belongs to relationships', function() {
         id: '2',
         type: 'maleMinion'
       }
-    }
+    },
+    name: 'Bobbie Sue'
+  });
+});
+
+test('serialize polymorphic belongs to relationships', function() {
+  var male, female;
+
+  Ember.run(function() {
+    // Of course they belong to each other
+    female = env.store.createRecord(FemaleMinion, {
+      id: 1,
+      name: 'Bobbie Sue'
+    });
+    male = env.store.createRecord(MaleMinion, {
+      id: 2,
+      spouse: female,
+      name: 'Billy Joe'
+    });
+  });
+
+  var json = Ember.run(function(){
+    var snapshot = male._createSnapshot();
+    return env.serializer.serialize(snapshot);
+  });
+
+  deepEqual(json, {
+    links: {
+      spouse: {
+        id: '1',
+        type: 'femaleMinion'
+      }
+    },
+    name: 'Billy Joe'
   });
 });
 


### PR DESCRIPTION
TypeKey must come from the model/snapshot, not from the relationship name. 

Replaces #57.
