### PR TITLE
WIP fix error consumption

### DIFF
--- a/src/json-api-serializer.js
+++ b/src/json-api-serializer.js
@@ -134,6 +134,18 @@ DS.JsonApiSerializer = DS.RESTSerializer.extend({
     return extracted;
   },
 
+  extractErrors: function(store, type, payload) {
+    var errors = {};
+    Ember.makeArray(payload.errors).forEach(function(error) {
+      Ember.makeArray(error.paths).forEach(function(path) {
+        path = camelize(path).replace(/^\//, '');
+        errors[path] = error[path] || [];
+        errors[path].push(error.code);
+      });
+    });
+    return errors;
+  },
+
   // SERIALIZATION
 
   /**

--- a/tests/index.html
+++ b/tests/index.html
@@ -41,6 +41,7 @@
   <script src='../tests/integration/specs/updating-an-individual-resource-test.js'></script>
   <script src='../tests/integration/specs/link-with-type.js'></script>
   <script src='../tests/integration/specs/null-relationship-test.js'></script>
+  <script src='../tests/integration/specs/deserializing-errors-test.js'></script>
   <script src='../tests/unit/adapter/ajax-error-test.js'></script>
   <script src='../tests/unit/adapter/build-url-test.js'></script>
   <script src='../tests/unit/serializer/extract-links-test.js'></script>

--- a/tests/integration/specs/deserializing-errors-test.js
+++ b/tests/integration/specs/deserializing-errors-test.js
@@ -1,0 +1,51 @@
+var get = Ember.get, set = Ember.set;
+var models, env;
+var responses, fakeServer;
+
+module('integration/specs/deserializing-errors', {
+  setup: function() {
+    fakeServer = stubServer();
+
+    responses = {
+      post_errors: {
+        errors: [
+          {
+            code: "blank",
+            title: "First Name cannot be blank",
+            paths: ["/first-name"]
+          }
+        ]
+      }
+    };
+
+    models = setModels();
+    env = setupStore(models);
+    env.store.modelFor('post');
+  },
+
+  teardown: function() {
+    Ember.run(env.store, 'destroy');
+    shutdownFakeServer(fakeServer);
+  }
+});
+
+asyncTest("PUT /posts/1 returns errors", function() {
+  var request = {
+    posts: {
+      title: '',
+      postSummary: null,
+      links: {
+        comments: []
+      }
+    }
+  };
+
+  fakeServer.post('/posts', request, responses.post_errors);
+
+  Em.run(function() {
+    env.store.createRecord(models.post, { title: '' }).save().then(function(record) {
+      equal(record.get('errors'), {title: ['blank']});
+      start();
+    });
+  });
+});


### PR DESCRIPTION
Work in progress to massage error payloads so ember-data will add them to `model.get('errors')`.

The `extractErrors()` override works for us on the application level, for a client's project, but when applying it to the add-on I'm still getting the same `Encountered "errors" in payload, but no model was found for model name "error"` message.

I found these checks under the `extractSingle()` and `extractArray()` methods, in ember-data:

```
var typeName  = this.typeForRoot(prop);

if (!store.modelFactoryFor(typeName)) {
  Ember.warn(this.warnMessageNoModelForKey(prop, typeName), false);
  continue;
}
```

I'm not sure how to get past them in overrides for above methods, yet. Any ideas?

closes #29 