### PR TITLE
Fixed path to main entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
       "email": "stefan.penner@gmail.com"
     }
   ],
-  "main": "dist/json-api-adapter.js",
+  "main": "ember-addon-main.js",
   "repository": {
     "type": "git",
     "url": "http://github.com/kurko/ember-json-api"


### PR DESCRIPTION
I've changed the path to the main entry of the package to be the Ember addon script by default. This should prevent the warning messages seen in #74. I took [the same issue](https://github.com/emberjs/data/pull/2842/files) in Ember Data as a reference.