### PR TITLE
Added a deprecation notice to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # ember-json-api
 
+>  **Deprecation Notice:** This addon was developed to add support for JSON API in Ember Data.
+>  With the release of Ember Data v1.13 support for JSON API was built-in, making this addon unnecessary.
+>  Since Ember Data now offers a similar feature set, we have decided to deprecate this addon.
+
+>  For more information on how to use the offical Ember Data solution see the [Ember 1.13 release notes](http://emberjs.com/blog/2015/06/18/ember-data-1-13-released.html).
+
 ![](https://travis-ci.org/kurko/ember-json-api.svg?branch=master)
 
 This is a [JSON API](http://jsonapi.org) adapter for [Ember Data](http://github.com/emberjs/data) 1.0 beta 19, that extends the built-in REST adapter. Please note that Ember Data and JSON API are both works in progress, use with caution.


### PR DESCRIPTION
@kurko I've added a deprecation notice to the README. I don't think I have ownership of the NPM module so you'll have to run this command real quick before merging:

`$ npm deprecate ember-json-api "ember-json-api is deprecated in favour of using the offical Ember Data adapter, for more information visit: http://emberjs.com/blog/2015/06/18/ember-data-1-13-released.html"`

As for the Bower package. I couldn't find a way to deprecate it in the docs.
